### PR TITLE
Add cities in en culture and update psm1 to include new function

### DIFF
--- a/NameIT.psm1
+++ b/NameIT.psm1
@@ -100,7 +100,7 @@ function Invoke-Generate {
     $script:alphabet = $alphabet
     $script:numbers = $number
 
-    $functionList = 'alpha|synonym|numeric|syllable|vowel|phoneticvowel|consonant|person|address|space|noun|adjective|verb|cmdlet|state|dave|guid|randomdate|fortnite'.Split('|')
+    $functionList = 'alpha|synonym|numeric|syllable|vowel|phoneticvowel|consonant|person|address|space|noun|adjective|verb|cmdlet|state|dave|guid|randomdate|fortnite|cities'.Split('|')
 
     if (-not $PSBoundParameters.ContainsKey("CustomDataFile")) {
         $customDataFile = "$PSScriptRoot\customData\customData.ps1"
@@ -251,9 +251,13 @@ function Get-RandomChoice {
 $nouns = Get-Content -Path "$PSScriptRoot\cultures\en-US.nouns.txt"
 $adjectives = Get-Content -Path "$PSScriptRoot\cultures\en-US.adjectives.txt"
 $verbs = Get-Content -Path "$PSScriptRoot\cultures\en-US.verbs.txt"
-
+$cities = Get-Content -Path "$PSScriptRoot\cultures\en-us.cities.txt"
 function noun {
     $nouns | Get-Random
+}
+
+function cities {
+    $cities | Get-Random
 }
 
 function adjective {

--- a/cultures/en-US.cities.txt
+++ b/cultures/en-US.cities.txt
@@ -1,0 +1,42 @@
+Albaquque
+Alberta
+Austin
+Boise
+Bamf
+Cleveland
+Columbus
+Cincinnati
+Charleston
+Charlotte
+Daytona Beach
+Denver
+Fredericksburg
+Frankfurt
+Fresno
+London
+Geneva
+Munich
+Paris
+Sicily
+Rome
+Sydney
+Tokyo
+Beijing
+Moscow
+Helsinki
+Rio De Janero
+Barcelona
+Houston
+Dallas
+Los Angeles
+Flagstaff
+Phoenix
+Salt Lake City
+Mexico City
+Portland
+Washington D.C.
+Boston
+Fort Myers
+Knoxville
+Louisville
+Indianapolis


### PR DESCRIPTION
It was convenient for me to have a cities function to be able to generate Office Locations for Active Directory objects in lab environments. Thought it would be a good thing to merge in. 