### PR TITLE
 New tests, bug fixes, random++

### DIFF
--- a/Generators/randomdate.ps1
+++ b/Generators/randomdate.ps1
@@ -24,8 +24,6 @@ function RandomDate {
         $Format = $Culture.DateTimeFormat.ShortDatePattern
     }
 
-    $theRandomGen = New-Object random
-    $theRandomTicks = [Convert]::ToInt64( ($MaxDate.ticks * 1.0 - $MinDate.Ticks * 1.0 ) * $theRandomGen.NextDouble() + $MinDate.Ticks * 1.0 )
-
-    (New-Object DateTime $theRandomTicks).ToString($Format, $Culture.DateTimeFormat)
+    $theRandomTicks = Get-Random -Minimum ([Convert]::ToDouble($MinDate.Ticks)) -Maximum ([Convert]::ToDouble($MaxDate.Ticks))
+    [DateTime]::new([Convert]::ToInt64($theRandomTicks)).ToString($Format, $Culture.DateTimeFormat)
 }

--- a/NameIT.psd1
+++ b/NameIT.psd1
@@ -4,7 +4,7 @@
     RootModule        = 'NameIT.psm1'
 
     # Version number of this module.
-    ModuleVersion     = '2.1.0'
+    ModuleVersion     = '2.1.1'
 
     # ID used to uniquely identify this module
     GUID              = '6d4ec85a-e09f-4024-819d-66bafa130a5b'

--- a/Private/GeneratorSet/Test-GeneratorInSet.ps1
+++ b/Private/GeneratorSet/Test-GeneratorInSet.ps1
@@ -6,7 +6,8 @@ function Test-GeneratorInSet {
             Mandatory ,
             ValueFromPipeline
         )]
-        [ValidateNotNullOrEmpty()]
+        [ValidateNotNull()]
+        [AllowEmptyString()]
         [String]
         $Name
     )

--- a/Private/Utility/Invoke-AllTests.ps1
+++ b/Private/Utility/Invoke-AllTests.ps1
@@ -1,0 +1,95 @@
+function Test-String{
+    param($p)
+
+     [PSCustomObject]@{
+        Test=$p -is [string]
+        DataType = "string"
+    }
+}
+
+ function Test-Date {
+    param($p)
+
+     [datetime]$result  = [datetime]::MinValue
+
+     [PSCustomObject]@{
+        Test=[datetime]::TryParse($p, [ref]$result)
+        DataType = "datetime"
+    }
+}
+
+ function Test-Boolean {
+    param($p)
+
+     #[bool]$result  = [bool]::FalseString
+    [bool]$result  = $false
+
+     [PSCustomObject]@{
+        Test=[bool]::TryParse($p, [ref]$result)
+        DataType = "bool"
+    }
+}
+
+ function Test-Number {
+    param($p)
+
+     [double]$result  = [double]::MinValue
+
+     [PSCustomObject]@{
+        Test=[double]::TryParse($p, [ref]$result)
+        DataType = "double"
+    }
+}
+
+ function Test-Integer {
+    param($p)
+
+     [int]$result  = [int]::MinValue
+
+     [PSCustomObject]@{
+        Test=[int]::TryParse($p, [ref]$result)
+        DataType = "int"
+    }
+}
+
+ $tests = [ordered]@{
+    TestBoolean = Get-Command Test-Boolean
+    TestInteger = Get-Command Test-Integer
+    TestNumber  = Get-Command Test-Number
+    TestDate    = Get-Command Test-Date
+    TestString  = Get-Command Test-String
+}
+
+ function Invoke-AllTests {
+    param(
+        $target,
+        [Switch]$OnlyPassing,
+        [Switch]$FirstOne
+    )
+
+     $resultCount=0
+    $tests.GetEnumerator() | ForEach {
+
+         $result=& $_.Value $target
+
+         $testResult = [PSCustomObject]@{
+            Test   = $_.Key
+            Target = $target
+            Result = $result.Test
+            DataType= $result.DataType
+        }
+
+         if(!$OnlyPassing) {
+            $testResult
+        } elseif ($result.Test -eq $true) {
+            if($FirstOne) {
+                if($resultCount -ne 1) {
+                    $testResult
+                    $resultCount+=1
+                }
+            } else {
+                $testResult
+            }
+        }
+    }
+} 

--- a/Public/Invoke-Generate.ps1
+++ b/Public/Invoke-Generate.ps1
@@ -97,9 +97,17 @@ function Invoke-Generate {
         [Switch]$AsPSObject ,
 
         [Parameter()]
+        [int]
+        $SetSeed ,
+
+        [Parameter()]
         [cultureinfo]
         $Culture = [cultureinfo]::CurrentCulture
     )
+
+    if ($PSBoundParameters.ContainsKey('SetSeed')) {
+        $null = Get-Random -SetSeed $SetSeed
+    } 
 
     $script:alphabet = $alphabet
     $script:numbers = $number
@@ -129,7 +137,7 @@ function Invoke-Generate {
                         Select-Object -Skip 1 |
                         ForEach-Object -Process {
                             if ($_.Type -eq [System.Management.Automation.PSTokenType]::String) {
-                                '{0}' -f [System.Management.Automation.Language.CodeGeneration]::EscapeSingleQuotedStringContent($_.Content)
+                                "'{0}'" -f [System.Management.Automation.Language.CodeGeneration]::EscapeSingleQuotedStringContent($_.Content)
                             } else {
                                 $_.Content
                             }

--- a/__tests__/nameit.tests.ps1
+++ b/__tests__/nameit.tests.ps1
@@ -2,6 +2,7 @@ $manifestPath = $PSScriptRoot | Join-Path -ChildPath '..' | Join-Path -ChildPath
 Import-Module $manifestPath -Force
 
 Describe "NameIT Tests" {
+    $StaticSeed = [System.Random]::new().Next()
 
     Context "Module Health" {
         It "Should have a valid module manifest" {
@@ -43,6 +44,52 @@ Describe "NameIT Tests" {
         It "Should pass through culture from Invoke-Generate" {
             $actual = Invoke-Generate -Template '[space 1]' -Culture ja-JP
             $actual -as [char] -as [int] | Should Be 12288
+        }
+
+        It "'[space]' and a literal space should return the same results" {
+            $spaceLit = Invoke-Generate -Template '[noun] [noun]' -SetSeed $StaticSeed
+            $spaceGen = Invoke-Generate -Template '[noun][space][noun]' -SetSeed $StaticSeed
+
+            $spaceLit | Should BeExactly $spaceGen
+        }
+
+        It "'[space 5]' and 5 literal spaces should return the same results" {
+            $spaceLit = Invoke-Generate -Template '[noun]     [noun]' -SetSeed $StaticSeed
+            $spaceGen = Invoke-Generate -Template '[noun][space 5][noun]' -SetSeed $StaticSeed
+
+            $spaceLit | Should BeExactly $spaceGen
+        }
+
+        It "Spaces in quoted arguments should behave" {
+            $dateHyphen = Invoke-Generate -Template "[randomdate 1/1/1999 5/5/5555 'yyyy-MM-dd']" -SetSeed $StaticSeed
+            $dateSpace = Invoke-Generate -Template "[randomdate 1/1/1999 5/5/5555 'yyyy MM dd']" -SetSeed $StaticSeed
+
+            $dateSpace | Should BeExactly $dateHyphen.Replace('-', ' ')
+        }
+
+        It "Newlines in a template should behave" {
+            { 
+                Invoke-Generate -Template '[noun]
+            
+                [noun]'
+            } | Should Not Throw
+        }
+
+        It "Newlines in a quoted argument should behave" {
+            # https://github.com/dfinke/NameIT/issues/29
+
+        #     $dateGen = Invoke-Generate -Template "[randomdate 1/1/1999 5/5/5555 'yyyy']" -SetSeed $StaticSeed
+        #     $dateNlGen = Invoke-Generate -Template "[randomdate 1/1/1999 5/5/5555 'yyyy
+        #     2
+        #     3']" -SetSeed $StaticSeed
+
+        #     "$dateGen
+        #     2
+        #     3" | Should BeExactly $dateNlGen
+        }
+
+        It "Internal Aliases shouldn't expand inside arguments" {
+            # https://github.com/dfinke/NameIT/issues/30
         }
     }
 }


### PR DESCRIPTION
- Add tests for reported and discovered bugs
- Add `-SetSeed` parameter to `Invoke-Generate` to aid in repeatable runs
(for tests mostly)
- Align `randomdate` generator to use `Get-Random` so that it inherits a set
seed
- Fix #27 (literal spaces aren't processed properly)
- Fix #28 (arguments with spaces fail even when specified properly)
- Verstion 2.1.1